### PR TITLE
close_event added

### DIFF
--- a/backend_kivy.py
+++ b/backend_kivy.py
@@ -1138,6 +1138,9 @@ class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
         self.figure.set_size_inches(winch, hinch)
         self.draw()
 
+    def on_deleted(self, instance, value):
+        self.close_event()
+
     def callback(self, *largs):
         self.draw()
 


### PR DESCRIPTION
I came across that close_event is missed in backend_kivy, but I need the widget to be notified when this happens in order to trigger the close_event.

Example:

https://gist.github.com/andnovar/dd85b6e0a17ba045f511

When the button is pressed I remove the widget from the floatlayout and the close_event is triggered. However I need to set a property in the Widget class to notify the figure canvas which is opened in this pr:

https://github.com/kivy/kivy/pull/3620
