### PR TITLE
Add timer support to kivy backend

### DIFF
--- a/backend_kivy.py
+++ b/backend_kivy.py
@@ -298,6 +298,7 @@ from kivy.properties import ObjectProperty
 from kivy.uix.textinput import TextInput
 from kivy.lang import Builder
 from kivy.logger import Logger
+from kivy.clock import Clock
 from distutils.version import LooseVersion
 
 _mpl_1_5 = LooseVersion(matplotlib.__version__) >= LooseVersion('1.5.0')
@@ -995,6 +996,39 @@ class GraphicsContextKivy(GraphicsContextBase, object):
         return attrib
 
 
+class TimerKivy(TimerBase):
+    '''
+    Subclass of :class:`backend_bases.TimerBase` that uses Kivy for timer events.
+    Attributes:
+    * interval: The time between timer events in milliseconds. Default
+        is 1000 ms.
+    * single_shot: Boolean flag indicating whether this timer should
+        operate as single shot (run once and then stop). Defaults to False.
+    * callbacks: Stores list of (func, args) tuples that will be called
+        upon timer events. This list can be manipulated directly, or the
+        functions add_callback and remove_callback can be used.
+    '''
+    def _timer_start(self):
+        # Need to stop it, otherwise we potentially leak a timer id that will
+        # never be stopped.
+        self._timer_stop()
+        self._timer = Clock.schedule_interval(self._on_timer, self._interval / 1000.0)
+
+    def _timer_stop(self):
+        if self._timer is not None:
+            Clock.unschedule(self._timer)
+            self._timer = None
+
+    def _timer_set_interval(self):
+        # Only stop and restart it if the timer has already been started
+        if self._timer is not None:
+            self._timer_stop()
+            self._timer_start()
+
+    def _on_timer(self, dt):
+        super(TimerKivy, self)._on_timer()
+
+
 class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
     '''FigureCanvasKivy class. See module documentation for more information.
 
@@ -1176,6 +1210,20 @@ class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
 
     def get_default_filetype(self):
         return 'png'
+
+    def new_timer(self, *args, **kwargs):
+        """
+        Creates a new backend-specific subclass of :class:`backend_bases.Timer`.
+        This is useful for getting periodic events through the backend's native
+        event loop. Implemented only for backends with GUIs.
+        optional arguments:
+        *interval*
+          Timer interval in milliseconds
+        *callbacks*
+          Sequence of (func, args, kwargs) where func(*args, **kwargs) will
+          be executed by the timer every *interval*.
+        """
+        return TimerKivy(*args, **kwargs)
 
 
 class FigureManagerKivy(FigureManagerBase):


### PR DESCRIPTION
In the process of getting animations to work, I added timer support to the kivy backend. Replaces #28 
