### PR TITLE
Window.size throws an error

### DIFF
--- a/backend_kivy.py
+++ b/backend_kivy.py
@@ -1244,7 +1244,7 @@ class FigureManagerKivy(FigureManagerBase):
         EventLoop.window.title = title
 
     def resize(self, w, h):
-        Window.size(w, h)
+        pass
 
     def _get_toolbar(self):
         if rcParams['toolbar'] == 'toolbar2':


### PR DESCRIPTION
Seems like the line Windows.size(x,y) is being called with the latest matplotlib 1.5. I tested it with 1.4.3 and it was not being called. This line is not needed for the backend to work in both mpl releases, neither master.
