### PR TITLE
Update backend_kivy.py

### DIFF
--- a/backend_kivy.py
+++ b/backend_kivy.py
@@ -1107,7 +1107,8 @@ class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
            `motion_notify_event`, `scroll_event`, `button_press_event`,
            `enter_notify_event` and `leave_notify_event`
         '''
-        newcoord = self.to_widget(touch.x, touch.y, relative=True)
+        x0,y0 = self.to_window(touch.x,touch.y)
+        newcoord = self.to_widget(x0,y0, relative=True)
         x = newcoord[0]
         y = newcoord[1]
 
@@ -1133,7 +1134,8 @@ class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
         '''Kivy Event to trigger the following matplotlib events:
            `motion_notify_event`, `enter_notify_event` and `leave_notify_event`
         '''
-        newcoord = self.to_widget(touch.x, touch.y, relative=True)
+        x0,y0 = self.to_window(touch.x,touch.y)
+        newcoord = self.to_widget(x0,y0, relative=True)
         x = newcoord[0]
         y = newcoord[1]
         inside = self.collide_point(touch.x, touch.y)
@@ -1165,7 +1167,8 @@ class FigureCanvasKivy(FocusBehavior, Widget, FigureCanvasBase):
         '''Kivy Event to trigger the following matplotlib events:
            `scroll_event` and `button_release_event`.
         '''
-        newcoord = self.to_widget(touch.x, touch.y, relative=True)
+        x0,y0 = self.to_window(touch.x,touch.y)
+        newcoord = self.to_widget(x0,y0, relative=True)
         x = newcoord[0]
         y = newcoord[1]
         if touch.grab_current is self:


### PR DESCRIPTION
While creating an application for my work, I ran into the following problem : If my graph widget based on this backend was integrated under a ScrollView widget, the touch event was missplaced by an offset proportionnal to the widget size. 
For example, if I tried to use the zoom-rect tool, my rubberband was not being drawn right under my mouse but slightly on the left and slightly lower as well. After some testing I found out that the touch event was not exactly in the window frame of reference anymore because of the ScrollView widget and thus, just letting kivy handle it by using self.to_window(touch.x,touch.y) was enough to solve the problem for my graph widget under a ScrollView widget and without any impact on my graph widgets that were not under one.
Hope this helps.